### PR TITLE
Add custom rejection option

### DIFF
--- a/index.js
+++ b/index.js
@@ -58,6 +58,8 @@ function csurf (options) {
     ? ['GET', 'HEAD', 'OPTIONS']
     : opts.ignoreMethods
 
+  var customReject = opts.customReject;
+
   if (!Array.isArray(ignoreMethods)) {
     throw new TypeError('option ignoreMethods must be an array')
   }
@@ -109,9 +111,13 @@ function csurf (options) {
 
     // verify the incoming token
     if (!ignoreMethod[req.method] && !tokens.verify(secret, value(req))) {
-      return next(createError(403, 'invalid csrf token', {
-        code: 'EBADCSRFTOKEN'
-      }))
+      if (customReject) {
+        req[customReject] = true;
+      } else {
+        return next(createError(403, 'invalid csrf token', {
+          code: 'EBADCSRFTOKEN'
+        }))
+      }
     }
 
     next()


### PR DESCRIPTION
Add an option to csurf that allows users to specify a key to put on the request object that it should be rejected. This allows them to subsequently reject the request by whatever means they prefer, instead of requiring http-error.
